### PR TITLE
Reduced Schedule

### DIFF
--- a/.github/workflows/update-google-stackdriver-debugger-java.yml
+++ b/.github/workflows/update-google-stackdriver-debugger-java.yml
@@ -1,7 +1,7 @@
 name: Update google-stackdriver-debugger-java
 "on":
     schedule:
-        - cron: 30 * * * *
+        - cron: 0 5 * * 1-5
     workflow_dispatch: {}
 jobs:
     update:

--- a/.github/workflows/update-google-stackdriver-debugger-nodejs.yml
+++ b/.github/workflows/update-google-stackdriver-debugger-nodejs.yml
@@ -1,7 +1,7 @@
 name: Update google-stackdriver-debugger-nodejs
 "on":
     schedule:
-        - cron: 30 * * * *
+        - cron: 0 5 * * 1-5
     workflow_dispatch: {}
 jobs:
     update:

--- a/.github/workflows/update-google-stackdriver-profiler-java.yml
+++ b/.github/workflows/update-google-stackdriver-profiler-java.yml
@@ -1,7 +1,7 @@
 name: Update google-stackdriver-profiler-java
 "on":
     schedule:
-        - cron: 30 * * * *
+        - cron: 0 5 * * 1-5
     workflow_dispatch: {}
 jobs:
     update:

--- a/.github/workflows/update-google-stackdriver-profiler-nodejs.yml
+++ b/.github/workflows/update-google-stackdriver-profiler-nodejs.yml
@@ -1,7 +1,7 @@
 name: Update google-stackdriver-profiler-nodejs
 "on":
     schedule:
-        - cron: 30 * * * *
+        - cron: 0 5 * * 1-5
     workflow_dispatch: {}
 jobs:
     update:


### PR DESCRIPTION
Previously, the regularly scheduled builds exhausted the free tier of GitHub actions in some orgs.  This change reduces the number of hours and number of days that these scheduled events will run.