### PR TITLE
Implement RFC 0050: Rename Buildpack

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # `gcr.io/paketo-buildpacks/google-stackdriver`
-The Paketo Google Stackdriver Buildpack is a Cloud Native Buildpack that contributes Stackdriver agents and configures them to connect to the service.
+The Paketo Buildpack for Google Stackdriver is a Cloud Native Buildpack that contributes Stackdriver agents and configures them to connect to the service.
 
 ## Behavior
 This buildpack will participate if any of the following conditions are met

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -19,7 +19,7 @@ api = "0.7"
   homepage = "https://github.com/paketo-buildpacks/google-stackdriver"
   id = "paketo-buildpacks/google-stackdriver"
   keywords = ["java", "node.js", "google-stackdriver"]
-  name = "Paketo Google Stackdriver Buildpack"
+  name = "Paketo Buildpack for Google Stackdriver"
   sbom-formats = ["application/vnd.cyclonedx+json", "application/vnd.syft+json"]
   version = "{{.version}}"
 


### PR DESCRIPTION
Renames 'Paketo Google Stackdriver Buildpack' to 'Paketo Buildpack for Google Stackdriver'.

Implements RFC 0050, https://github.com/paketo-buildpacks/rfcs/issues/233, for this buildpack.

Signed-off-by: Daniel Mikusa <dmikusa@vmware.com>
