### PR TITLE
Adds detection logging messages at info level

### DIFF
--- a/cmd/main/main.go
+++ b/cmd/main/main.go
@@ -26,8 +26,9 @@ import (
 )
 
 func main() {
+	logger := bard.NewLogger(os.Stdout)
 	libpak.Main(
-		stackdriver.Detect{},
-		stackdriver.Build{Logger: bard.NewLogger(os.Stdout)},
+		stackdriver.Detect{Logger: logger},
+		stackdriver.Build{Logger: logger},
 	)
 }

--- a/stackdriver/detect.go
+++ b/stackdriver/detect.go
@@ -21,9 +21,12 @@ import (
 
 	"github.com/buildpacks/libcnb"
 	"github.com/paketo-buildpacks/libpak/bindings"
+	"github.com/paketo-buildpacks/libpak/bard"
 )
 
-type Detect struct{}
+type Detect struct{
+	Logger bard.Logger
+}
 
 func (d Detect) Detect(context libcnb.DetectContext) (libcnb.DetectResult, error) {
 	result := libcnb.DetectResult{Pass: false}
@@ -53,6 +56,7 @@ func (d Detect) Detect(context libcnb.DetectContext) (libcnb.DetectResult, error
 				},
 			},
 		)
+		d.Logger.Info("PASSED: binding of type 'StackdriverDebugger' found")
 	}
 
 	if _, ok, err := bindings.ResolveOne(context.Platform.Bindings, bindings.OfType("StackdriverProfiler")); err != nil {
@@ -80,7 +84,11 @@ func (d Detect) Detect(context libcnb.DetectContext) (libcnb.DetectResult, error
 				},
 			},
 		)
+		d.Logger.Info("PASSED: binding of type 'StackdriverProfiler' found")
 	}
 
+	if result.Pass != true {
+		d.Logger.Info("SKIPPED: no bindings of type 'StackdriverDebugger' or 'StackdriverProfiler' found")
+	}
 	return result, nil
 }


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
This PR adds additional logging when Detect returns false for this buildpack. This is to provide more information about why the detection failed for this buildpack when verbose/debug logging is enabled.

As of lifecycle v1.16.0, if the detect phase fails as a whole, log messages are printed at info level by default, without the need for the verbose flag.

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
